### PR TITLE
Add missing dependency: dns-agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "mocha": "^3.4.1"
     },
     "dependencies": {
-        "overload2": "^0.2.0"
+        "overload2": "^0.2.0",
+        "dns-agent": "0.0.2"
     }
 }


### PR DESCRIPTION
I tried using the osapi npm module today, found it crashing due to a missing dependency on this module. 